### PR TITLE
Fix the WINDOW FOCUS events

### DIFF
--- a/src/cursor.c
+++ b/src/cursor.c
@@ -1643,7 +1643,7 @@ DO_CURSOR(cursor_screen_focus_in)
 {
 	gtd->screen->focus = 1;
 
-	check_all_events(gtd->ses, SUB_ARG, 1, 1, "SCREEN FOCUS", ntos(gtd->screen->focus));
+	check_all_events(gtd->ses, SUB_ARG, 1, 1, "WINDOW FOCUS IN", ntos(gtd->screen->focus));
 
 	msdp_update_all("SCREEN_FOCUS", "%d", gtd->screen->focus);
 }
@@ -1652,7 +1652,7 @@ DO_CURSOR(cursor_screen_focus_out)
 {
 	gtd->screen->focus = 0;
 
-	check_all_events(gtd->ses, SUB_ARG, 0, 1, "SCREEN FOCUS", ntos(gtd->screen->focus));
+	check_all_events(gtd->ses, SUB_ARG, 0, 1, "WINDOW FOCUS OUT", ntos(gtd->screen->focus));
 
 	msdp_update_all("SCREEN_FOCUS", "%d", gtd->screen->focus);
 }

--- a/src/tables.c
+++ b/src/tables.c
@@ -931,14 +931,14 @@ struct cursor_type cursor_table[] =
 		cursor_redraw_input
 	},
 	{
-		"SCREEN FOCUS IN",
+		"WINDOW FOCUS IN",
 		"Window is focussed in event",
 		"\e[I",
 		CURSOR_FLAG_GET_ALL|CURSOR_FLAG_ALWAYS,
 		cursor_screen_focus_in
 	},
 	{
-		"SCREEN FOCUS OUT",
+		"WINDOW FOCUS OUT",
 		"Window is focussed out event",
 		"\e[O",
 		CURSOR_FLAG_GET_ALL|CURSOR_FLAG_ALWAYS,


### PR DESCRIPTION
The `WINDOW FOCUS (IN|OUT)` events were actually being raised as a single `SCREEN FOCUS` event. This changes the events to be raised in the proper `WINDOW FOCUS` incarnation so that the handlers are actually usable.