### PR TITLE
tintin.h: add limits.h include

### DIFF
--- a/src/tintin.h
+++ b/src/tintin.h
@@ -38,6 +38,7 @@
 #include <math.h>
 #include <stdbool.h>
 #include <sys/socket.h>
+#include <limits.h>
 
 /******************************************************************************
 *   Autoconf patching by David Hedbor                                         *


### PR DESCRIPTION
This is required for `PATH_MAX`. That's used as of 7ea23cc7075bd07ed126378c61009b916e9149c6, but no matching include was added; that broke the build on platforms where `limits.h` isn't being passively included via something else.