### PR TITLE
Fix Makefile

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -56,6 +56,11 @@ DEFAULT_FILE_DIR = $(HOME)
 
 FFLAGS= $(F1) $(F6)
 
+HEADERS = \
+config.h \
+dict.h \
+telnet.h \
+tintin.h
 
 OFILES = \
 files.o help.o trigger.o input.o main.o misc.o net.o parse.o debug.o \
@@ -71,7 +76,7 @@ default: all
 all:	tt++
 
 
-tt++:	Makefile $(OFILES) tintin.h
+tt++:	Makefile $(OFILES)
 	@echo "---- Linking..."
 	$(CC) $(INCS) $(CFLAGS) $(FFLAGS) $(LDFLAGS) -o $@ $(OFILES) $(LIBS) ${LIBSOCKS}
 
@@ -89,7 +94,7 @@ install: tt++
 
 
 # Autocompile all .c files into .o files using this rule:
-.c.o:
+%.o: %.c $(HEADERS)
 	$(CC) $(PIPE) $(CFLAGS) $(FFLAGS) $(INCS) -c $<
 
 


### PR DESCRIPTION
Add header files as dependency to object files. This causes object to be rebuilt when header files change. This is necessary since the header files are part of the translation unit for each object file (i.e. the header files are part of the input to the compiler, along with the object file's .c file, so since the input sent to the compiler has changed, the compiler output will of course be different, and that needs to be reflected in the makefile's dependencies).

Technically, each object file only needs to depend on those header files that are included. I just added them all. You can always go through each and make sure only those header files that are included in the obj file's source (including transitive includes) are marked as a dependency.