### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/tintin.h
+++ b/src/tintin.h
@@ -98,6 +98,10 @@
 #include <sys/stat.h>
 #endif
 
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+
 #if !defined(SO_PEERCRED)
 	#define SO_PEERCRED 17
 #endif


### PR DESCRIPTION
The error message is as follows:
```
cc -g -Wall  -O2 -pipe  -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing  -D_GNU_SOURCE -DHAVE_CONFIG_H -DBIG5   -I/usr/local/include -c net.c
net.c:82:6: warning: implicit declaration of function 'getsockopt' is invalid in C99 [-Wimplicit-function-declaration]
        if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &val, &len) == -1)
            ^
net.c:82:23: error: use of undeclared identifier 'SOL_SOCKET'
        if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &val, &len) == -1)
                             ^
net.c:82:35: error: use of undeclared identifier 'SO_ERROR'
        if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &val, &len) == -1)
                                         ^
net.c:116:22: error: use of undeclared identifier 'AF_INET'
        hints.ai_family   = AF_INET;
                            ^
net.c:118:22: error: use of undeclared identifier 'SOCK_STREAM'
        hints.ai_socktype = SOCK_STREAM;
                            ^
net.c:124:21: error: use of undeclared identifier 'AF_INET6'
                hints.ai_family = AF_INET6;
                                  ^
net.c:136:9: warning: implicit declaration of function 'socket' is invalid in C99 [-Wimplicit-function-declaration]
        sock = socket(address->ai_family, address->ai_socktype, address->ai_protocol);
               ^
net.c:147:23: warning: implicit declaration of function 'connect' is invalid in C99 [-Wimplicit-function-declaration]
        ses->connect_error = connect(sock, address->ai_addr, address->ai_addrlen);
                             ^
3 warnings and 5 errors generated.
gmake[1]: *** [Makefile:96: net.o] Error 1
```