### PR TITLE
enable TCP keepalive

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -145,9 +145,11 @@ int connect_mud(struct session *ses, char *host, char *port)
 		return -1;
 	}
 
-    int optval = 1;
-    socklen_t optlen = sizeof(optval);
-    setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &optval, optlen);
+	int optval = 1;
+	if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval)) < 0)
+	{
+		syserr_printf(ses, "connect_mud: unable to use tcp keepalive, continuing without");
+	}
 
 	ses->connect_error = connect(sock, address->ai_addr, address->ai_addrlen);
 

--- a/src/net.c
+++ b/src/net.c
@@ -145,6 +145,10 @@ int connect_mud(struct session *ses, char *host, char *port)
 		return -1;
 	}
 
+    int optval = 1;
+    socklen_t optlen = sizeof(optval);
+    setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &optval, optlen);
+
 	ses->connect_error = connect(sock, address->ai_addr, address->ai_addrlen);
 
 	if (fcntl(sock, F_SETFL, O_NDELAY|O_NONBLOCK) == -1)


### PR DESCRIPTION
This patch enables the SO_KEEPALIVE option on the host socket, so tintin can make use of the kernel's tcp_keepalive feature.

Background: my ISP recently reconfigured the NAT timeout on their routers to 1 minute, which causes a MUD connection to break regularly.