### PR TITLE
fix: cursor postion in trigger

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -636,7 +636,7 @@ void process_mud_output(struct session *ses, char *linebuf, int prompt)
 		
 		str_cpy(&output, linebuf);
 
-		print_line(ses, &output, prompt);
+		print_line_scroll_region(ses, &output, prompt);
 
 		if (!IS_SPLIT(ses))
 		{

--- a/src/screen.c
+++ b/src/screen.c
@@ -2296,3 +2296,19 @@ void add_line_screen(struct session *ses, char *str, int row)
 	pop_call();
 	return;
 }
+
+void print_line_scroll_region(struct session *ses, char **str, int prompt)
+{
+	if (HAS_BIT(ses->flags, SES_FLAG_SPLIT))
+	{
+		save_pos(ses);
+		goto_pos(ses, ses->split->bot_row, 1);
+	}
+
+	print_line(ses, str, prompt);
+
+	if (HAS_BIT(ses->flags, SES_FLAG_SPLIT))
+	{
+		restore_pos(ses);
+	}
+}

--- a/src/tintin.h
+++ b/src/tintin.h
@@ -2687,6 +2687,7 @@ extern void add_row_index(struct row_data **row, int index);
 extern void del_row_index(struct row_data **row, int index);
 
 extern void print_scroll_region(struct session *ses);
+extern void print_line_scroll_region(struct session *ses, char **str, int prompt);
 extern void print_screen();
 extern void init_screen(int rows, int cols, int pix_rows, int pix_cols);
 extern void destroy_screen();


### PR DESCRIPTION
When the code in the trigger executes some code that may affect the cursor position (e.g. a simple #split).

The easiest way to get around this is to use `#delay 0 #split`, but I think the root cause of it is due to the fact that the print mud output doesn't ensure that it must be print in the scroll region.

For code readability reasons, I added a function to do this.

This should close #113