### PR TITLE
fix: background color bleeding in long line

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -2165,12 +2165,12 @@ void print_scroll_region(struct session *ses)
 
 	for (cnt = ses->split->top_row ; cnt < ses->split->bot_row ; cnt++)
 	{
-		print_stdout(0, 0, "\e[%d;%dH\e[%dX%s", cnt, ses->split->top_col, ses->wrap, gtd->screen->line[cnt - 1]->str);
+		print_one_line_with_erase(ses, cnt, ses->split->top_col, gtd->screen->line[cnt - 1]->str, ses->split->bot_col - ses->split->top_col + 1);
 	}
 
 	word_wrap_split(ses, ses->scroll->input, wrap, ses->wrap, 0, 1, WRAP_FLAG_SPLIT, &height, &width);
 
-	print_stdout(0, 0, "\e[%d;%dH\e[%dX%s", cnt, ses->split->top_col, ses->wrap, wrap);
+	print_one_line_with_erase(ses, cnt, ses->split->top_col, wrap, ses->split->bot_col - ses->split->top_col + 1);
 
 	restore_pos(ses);
 

--- a/src/text.c
+++ b/src/text.c
@@ -25,6 +25,24 @@
 
 #include "tintin.h"
 
+void print_one_line_with_erase(struct session *ses, int row, int col, char *line, int line_width)
+{
+	int erase_width;
+
+	if (row && col)
+	{
+		print_stdout(0, 0, "\e[%d;%dH", row, col);
+	}
+
+	print_stdout(0, 0, "%s", line);
+
+	erase_width = line_width - str_len_str(ses, line, 0, strlen(line));
+
+	if (erase_width > 0)
+	{
+		print_stdout(0, 0, "\e[%dX", erase_width);
+	}
+}
 
 void print_line(struct session *ses, char **str, int prompt)
 {
@@ -78,7 +96,19 @@ void print_line(struct session *ses, char **str, int prompt)
 	}
 	else
 	{
-		print_stdout(0, 0, "%s\n", out);
+		char *eol;
+		eol = strchr(out, '\n');
+		while(eol)
+		{
+			*eol++ = 0;
+			print_one_line_with_erase(ses, 0, 0, out, gtd->screen->width);
+			print_stdout(0, 0, "\n");
+			out = eol;
+			eol = strchr(out, '\n');
+		}
+
+		print_one_line_with_erase(ses, 0, 0, out, gtd->screen->width);
+		print_stdout(0, 0, "\n");
 	}
 
 //	add_line_screen(out);

--- a/src/tintin.h
+++ b/src/tintin.h
@@ -2784,6 +2784,7 @@ extern int get_raw_off_str_range_raw_width(struct session *ses, char *str, int s
 
 extern int raw_len_str(struct session *ses, char *str, int start, int end);
 extern int str_len_raw(struct session *ses, char *str, int start, int end);
+extern int str_len_str(struct session *ses, char *str, int start, int end);
 
 extern char *str_ins_str(struct session *ses, char **str, char *ins, int str_start, int str_end);
 
@@ -2899,6 +2900,7 @@ extern char *get_charset(struct session *ses);
 #define __TEXT_H__
 
 extern void print_line(struct session *ses, char **str, int isaprompt);
+extern void print_one_line_with_erase(struct session *ses, int row, int col, char *line, int line_width);
 extern void print_stdout(int row, int col, char *format, ...);
 extern  int word_wrap(struct session *ses, char *textin, char *textout, int display, int *height, int *width);
 extern  int word_wrap_split(struct session *ses, char *textin, char *textout, int wrap, int start, int end, int flags, int *height, int *width);


### PR DESCRIPTION
MWE:

```
#echo {<171>HELLO\nBUG<172>line1\nline2<070>END}
```

BEFORE(both split mode and unsplit mode):

<img width="507" alt="image" src="https://user-images.githubusercontent.com/52447680/198183690-9a17f6ee-5511-4fdb-b97b-3b8837461462.png">

AFTER

<img width="506" alt="image" src="https://user-images.githubusercontent.com/52447680/198184698-e3e142de-9b2c-4473-b8d3-d9233030506b.png">
