### PR TITLE
fix: a memory access error caused by a typo

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -916,7 +916,7 @@ void echo_command(struct session *ses, char *line)
 	{
 		strcpy(output, ses->more_output);
 
-		process_mud_output(ses, buffer, FALSE);
+		process_mud_output(ses, output, FALSE);
 	}
 	else
 	{


### PR DESCRIPTION
@scandum  Is there a spelling error here, where output is written as buffer?

I was investigating a suspected memory access violation error and the final suspicion pointed here. It looks like an uninitialized buffer is being accessed here?