### PR TITLE
telopt_client: TINTIN_FLAG_MOUSETRACKING from gtd, not ses

### DIFF
--- a/src/telopt_client.c
+++ b/src/telopt_client.c
@@ -606,7 +606,7 @@ int get_mtts_val(struct session *ses)
 		+ (HAS_BIT(ses->flags, SES_FLAG_SPLIT) ? 0 : 2)
 		+ (HAS_BIT(ses->charset, CHARSET_FLAG_UTF8) && !HAS_BIT(ses->charset, CHARSET_FLAG_ALL_TOUTF8) ? 4 : 0)
 		+ (ses->color > 16 ? 8 : 0)
-		+ (HAS_BIT(ses->flags, TINTIN_FLAG_MOUSETRACKING) ? 16 + 1024 : 0)
+		+ (HAS_BIT(gtd->flags, TINTIN_FLAG_MOUSETRACKING) ? 16 + 1024 : 0)
 		+ (HAS_BIT(ses->config_flags, CONFIG_FLAG_SCREENREADER) ? 64 : 0)
 //		+ proxy ? 128 : 0
 		+ (ses->color > 256 ? 256 : 0)


### PR DESCRIPTION
... as nothing is setting that flag on "ses":

    $ git grep 'SET.*MOUSETRACKING'
    src/config.c:            SET_BIT(gtd->flags, TINTIN_FLAG_MOUSETRACKING);
    src/config.c:            SET_BIT(gtd->flags, TINTIN_FLAG_MOUSETRACKING);
    src/config.c:            SET_BIT(gtd->flags, TINTIN_FLAG_MOUSETRACKING);
    src/config.c:            SET_BIT(gtd->flags, TINTIN_FLAG_MOUSETRACKING);

With this change, connecting to a MUD which supports MTTS while having done:

    #config mouse on

... properly sets the bits for "MOUSE TRACKING" and "MSLP", as it probably should.

Previous to this change, it couldn't - as that bit is never set on "ses" so it reported that it couldn't do mouse tracking OR MSLP, despite being perfectly able to (due to the `#config mouse on`, which the docs say is the minimum prerequisite for MSLP support):

    MSLP (Mud Server Link Protocol) requires enabling #config mouse on,
     and creating the appropriate LINK events.