### PR TITLE
ssl: add the SNI extension

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -70,6 +70,7 @@ gnutls_session_t ssl_negotiate(struct session *ses)
 	gnutls_set_default_priority(ssl_ses);
 	gnutls_credentials_set(ssl_ses, GNUTLS_CRD_CERTIFICATE, ssl_cred);
 	gnutls_transport_set_ptr(ssl_ses, (gnutls_transport_ptr_t) (long int) ses->socket);
+	gnutls_server_name_set(ssl_ses, GNUTLS_NAME_DNS, ses->session_host, strlen(ses->session_host));
 
 	do 
 	{


### PR DESCRIPTION
This is important for servers behind a load balancer that multiplexes connections to multiple different backends based on the SNI extension in the Client Hello message.