### PR TITLE
feat: support %f for us and %q for ms in #format {%t}, also in #log timestamp

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -268,13 +268,12 @@ void logit(struct session *ses, char *txt, FILE *file, int flags)
 	{
 		if (ses->log->stamp_time != gtd->time)
 		{
-			struct tm timeval_tm = *localtime(&gtd->time);
-
 			ses->log->stamp_time = gtd->time;
 
 			substitute(ses, ses->log->stamp_strf, out, SUB_COL|SUB_ESC|SUB_VAR|SUB_FUN);
 
-			strftime(ses->log->stamp_text, 99, out, &timeval_tm);
+			timestring(ses, out);
+			strcpy(ses->log->stamp_text, out);
 		}
 		fputs(ses->log->stamp_text, file);
 	}

--- a/src/tintin.h
+++ b/src/tintin.h
@@ -3044,6 +3044,7 @@ extern void  charactertonumber(struct session *ses, char *str);
 extern  int  delete_variable(struct session *ses, char *variable);
 extern void  justify_string(struct session *ses, char *in, char *out, int align, int cut);
 extern void  format_string(struct session *ses, char *format, char *arg, char *out);
+extern void  timestring(struct session *ses, char *str);
 extern struct listnode *search_variable(struct session *ses, char *variable);
 extern struct listnode *get_variable(struct session *ses, char *variable, char *result);
 extern struct listnode *set_variable(struct session *ses, char *variable, char *format, ...);


### PR DESCRIPTION
tt's time string formatting methods currently only support those already available in POSIX strftime, which do not include milliseconds and microseconds. This often feels a bit insufficient when printing logs for fine-grained analysis. For this reason I have added support for milliseconds and microseconds.

The %f for microseconds is consistent with Python. Using %q for milliseconds is a no-brainer because I looked at the documentation for strftime and found that almost all the letters (both case and lowercase) were already taken, except %q, which I chose.

Considering that tt++ scripts are less likely to interoperate with other languages, and that timestamping isn't really a high-frequency feature to change, I don't think it should be too much of a problem.
Or if you have a better suggestion, please let me know.