### PR TITLE
Fix: report unavailability of SNOOP to MMCP peer

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -965,6 +965,7 @@ void get_chat_commands(struct chat_data *buddy, char *buf, int len)
 				break;
 
 			case CHAT_SNOOP_START:
+				chat_socket_printf(buddy, "%c%s%c", CHAT_MESSAGE, "\nTintin++ does not natively support this; ask peer via a message to FORWARD, FORWARDALL or SERVE you instead.\n", CHAT_END_OF_COMMAND);
 				break;
 
 			case CHAT_SNOOP_DATA:


### PR DESCRIPTION
Sends a message back to the peer if it sends a "SNOOP" command to TinTin++ as this MUD client does not (currently?) allow the peer to request to receive the text/messages that it has received; instead the local TinTin++ user must themselves configure it to send the data out to each peer manually with the appropriate CHAT FORWARD/FORWARDALL/SERVE command.