### PR TITLE
fix: Fix memory issue on session dispose

### DIFF
--- a/src/class.c
+++ b/src/class.c
@@ -145,7 +145,7 @@ int count_class(struct session *ses, struct listnode *group)
 
 	for (cnt = list = 0 ; list < LIST_MAX ; list++)
 	{
-		if (!HAS_BIT(ses->list[list]->flags, LIST_FLAG_CLASS))
+		if (ses->list[list] == NULL || !HAS_BIT(ses->list[list]->flags, LIST_FLAG_CLASS))
 		{
 			continue;
 		}
@@ -170,7 +170,7 @@ void clear_class(struct session *ses, struct listnode *group)
 
 	for (type = 0 ; type < LIST_MAX ; type++)
 	{
-		if (!HAS_BIT(ses->list[type]->flags, LIST_FLAG_CLASS))
+		if (ses->list[type] == NULL || !HAS_BIT(ses->list[type]->flags, LIST_FLAG_CLASS))
 		{
 			continue;
 		}

--- a/src/session.c
+++ b/src/session.c
@@ -778,6 +778,7 @@ void dispose_session(struct session *ses)
 	for (index = 0 ; index < LIST_MAX ; index++)
 	{
 		free_list(ses->list[index]);
+		ses->list[index] = NULL;
 	}
 
 	init_buffer(ses, 0);


### PR DESCRIPTION
When a session is destroyed, the cleanup code goes through all the session's lists, cleaning them up and freeing them one by one.

The `class` list is the 4th list in this process, but while clearing classes it will go through all lists again to see if anything belongs to that class, including the first 3 that are already deleted (`action`, `alias` and `button`). The pointer it uses (`ses->list[n]`) will point to already freed memory for n = 0, 1 or 2.

This often goes through undetected since the freed memory still contains the same data, but if for some reason that memory location is reused during the session cleanup, it will usually result in a segfault.

This fix makes sure the pointers are set to `NULL` after freeing the memory so that it can be identified as already freed and not accessed again.