### PR TITLE
Fix warnings

### DIFF
--- a/src/mapper.c
+++ b/src/mapper.c
@@ -3865,7 +3865,7 @@ void search_keywords(struct session *ses, char *arg, char *out, char *var)
 		}
 	}
 
-	if (buf[MAP_SEARCH_DESC])
+	if (*buf[MAP_SEARCH_DESC])
 	{
 		str = buf[MAP_SEARCH_DESC];
 

--- a/src/regex.c
+++ b/src/regex.c
@@ -212,12 +212,10 @@ pcre *regexp_compile(struct session *ses, char *exp, int comp_option)
 
 int check_one_regexp(struct session *ses, struct listnode *node, char *line, char *original, int comp_option)
 {
-	char *exp, *str;
+	char *exp, *str, result[BUFFER_SIZE];
 
 	if (node->regex == NULL)
 	{
-		char result[BUFFER_SIZE];
-
 		substitute(ses, node->arg1, result, SUB_VAR|SUB_FUN);
 
 		exp = result;

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -316,7 +316,7 @@ static int ssl_check_cert(struct session *ses, gnutls_session_t ssl_ses)
 		{
 			if (err)
 			{
-				sprintf(buf2, "CERTIFICATE MISMATCH, AND NEW %s", err);
+				sprintf(buf2, "CERTIFICATE MISMATCH, AND NEW %.*s", (BUFFER_SIZE-31), err);
 			}
 			else
 			{


### PR DESCRIPTION
Fixes the compiler warnings I got for `2.02.51`

I'm not entirely sure I got the mapper one right, but I'm hoping it's obviously correct/wrong to someone who properly knows C
The warning I got before was
```
mapper.c:3868:13: warning: the comparison will always evaluate as ‘true’ for the address of ‘buf’ will never be NULL [-Waddress]
 3868 |         if (buf[MAP_SEARCH_DESC])
      |             ^~~
```