### PR TITLE
Add output line expansion to arg substitution.

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -616,7 +616,11 @@ void process_more_output(struct session *ses, char *append, int prompt)
 	str_cpy(&ses->more_output, "");
 	ses->check_output = 0;
 
+	gtd->mud_output_line = line;
+
 	process_one_line(ses, line, prompt);
+
+	gtd->mud_output_line = gtd->mud_output_buf + gtd->mud_output_len;
 
 	if (readmud == 0)
 	{

--- a/src/substitute.c
+++ b/src/substitute.c
@@ -1634,7 +1634,7 @@ int substitute(struct session *ses, char *string, char *result, int flags)
 				break;
 
 			case '%':
-				if (HAS_BIT(flags, SUB_ARG) && (is_digit(pti[1]) || pti[1] == '%'))
+				if (HAS_BIT(flags, SUB_ARG) && ((is_digit(pti[1]) || pti[1] == '%') || pti[1] == '~'))
 				{
 					if (pti[1] == '%')
 					{
@@ -1651,6 +1651,11 @@ int substitute(struct session *ses, char *string, char *result, int flags)
 							*pto++ = *pti++;
 						}
 					}
+                    else if (pti[1] == '~')
+                    {
+                        pto += sprintf(pto, "%s", gtd->mud_output_line);
+					    pti += 2;
+                    }
 					else
 					{
 						i = is_digit(pti[2]) ? (pti[1] - '0') * 10 + pti[2] - '0' : pti[1] - '0';


### PR DESCRIPTION
Here is a change for your consideration which exposes a new substitutable argument `%~` and resolves to the current unstripped output line which retains all vt102 codes.

```
#action {^You say, '%1'$} {
  #line log chat.log {%~};
}

#action {^%1 gossips, '%2'$} {
  #line log chat.log {%~};
  #line gag;
}
```

This is useful in cases where a user wishes to match on text, without context of ansii escape codes, and then subsequently log the raw colorized text.   Such as in cases where gossip, tells, etc.. are being logged to a file but the actual colors are not relevant to the context of the message.

Various other avenues have been explored to accomplish this, and while they work, they each have exposed certain limitations. 

**Attempt 1**

```
#var {LINE} {};
#event {RECEIVED LINE} { 
  #if {"%1" != ""} {#var {LINE} {%0}};
}

#action {^%1 tells you, '%2'$} { 
  #line log chat.log {$LINE};
}
```
This technique relies on the `RECEIVED LINE` event which unfortunately reports a multiline string in some cases. As a result $LINE may not technically be representative of the actual line for which the action triggered.

**Attempt 2**

```
#action {^%1 tells you, '%2'$} { 
  #line oneshot #event {PROCESSED LINE} {#line log chat.log {%%0}
}
```

As a revision of this first attempt, it does not appear to suffer from the multline issue, however it prevents the user from being able to log the line **and** simultaneously gag it;  this is because gaging the line would cause the `PROCESSED LINE` event to not trigger. It also suffers from the known limitation that the event may not already be in use.

Both techniques require an event handler to trigger some code on each tick - this may be considered unnecessary in terms of performance.  Given the backend already stores the known `output_line` as a char ptr, it seems fitting to me to expose it to script in this manner.

Appreciate your consideration and happy to make revisions if you consider it further.  I have been running this code for a week w/o issue.