### PR TITLE
Contain colors to individual symbol map cells

### DIFF
--- a/src/mapper.c
+++ b/src/mapper.c
@@ -3815,6 +3815,10 @@ char *draw_room(struct session *ses, struct room_data *room, int line, int x, in
 			}
 		}
 	}
+	if (HAS_BIT(ses->map->flags, MAP_FLAG_SYMBOLGRAPHICS))
+	{
+		cat_sprintf(buf, "%s%s", COLOR_RESET, ses->map->color[MAP_COLOR_BACK]);
+	}
 	pop_call();
 	return buf;
 }


### PR DESCRIPTION
Reset the color state after each rendered symbol-map cell, then restore the configured map background, so a room's background applies only to that cell.

---

Room colors containing a background color can bleed across subsequent cells when rendering a symbol map. Most room colors only change the foreground, so they do not clear the inherited background.

This is reproducible with a room color like `<029><BBB>` followed by rooms using foreground-only colors. The background currently continues across the row until another color explicitly resets it.

<img width="1546" height="686" alt="image" src="https://github.com/user-attachments/assets/90eb8645-eb85-4865-8a79-439276f060ea" />

(example of the bleeding I noticed.. resolved with this fix)