### PR TITLE
Fix assorted memory-safety bugs and memory leaks

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -867,7 +867,7 @@ void get_chat_commands(struct chat_data *buddy, char *buf, int len)
 
 		*pto-- = 0;
 
-		while (is_space(*pto))
+		while (pto >= (unsigned char *) txt && is_space(*pto))
 		{
 			*pto-- = 0;
 		}

--- a/src/chat.c
+++ b/src/chat.c
@@ -529,6 +529,11 @@ void close_chat(struct chat_data *buddy, int unlink)
 
 	close(buddy->fd);
 
+	if (buddy->file_pt)
+	{
+		fclose(buddy->file_pt);
+	}
+
 	free(buddy->color);
 	free(buddy->download);
 	free(buddy->group);
@@ -537,6 +542,7 @@ void close_chat(struct chat_data *buddy, int unlink)
 	free(buddy->prefix);
 	free(buddy->reply);
 	free(buddy->version);
+	free(buddy->file_name);
 
 	free(buddy);
 }

--- a/src/event.c
+++ b/src/event.c
@@ -348,8 +348,8 @@ void mouse_handler(struct session *ses, int flags, int row, int col)
 
 //		if (flags == 8) tintin_printf2(NULL, "debug: rpx %4d/%d cpx %4d/%d\n\n\n", char_row, gtd->screen->char_height, char_col, gtd->screen->char_width);
 
-		grid_pos  = char_row * 3 / gtd->screen->char_height * 3;
-		grid_pos += char_col * 3 / gtd->screen->char_width;
+		grid_pos  = (char_row - 1) * 3 / gtd->screen->char_height * 3;
+		grid_pos += (char_col - 1) * 3 / gtd->screen->char_width;
 	}
 	else
 	{

--- a/src/files.c
+++ b/src/files.c
@@ -54,7 +54,7 @@ DO_COMMAND(do_read)
 
 struct session *read_file(struct session *ses, FILE *file, char *filename)
 {
-	char *bufi, *bufo, temp[INPUT_SIZE], *pti, *pto, last = 0;
+	char *bufi = NULL, *bufo = NULL, temp[INPUT_SIZE], *pti, *pto, last = 0;
 	int lvl, cnt, com, lnc, fix, ok, verbose, size;
 	int counter[LIST_MAX];
 
@@ -91,6 +91,9 @@ struct session *read_file(struct session *ses, FILE *file, char *filename)
 
 		tintin_printf(ses, "#ERROR: #READ {%s}: FAILED TO ALLOCATE %d BYTES OF MEMORY.", filename, size + 2);
 
+		free(bufi);
+		free(bufo);
+
 		return ses;
 	}
 
@@ -100,6 +103,9 @@ struct session *read_file(struct session *ses, FILE *file, char *filename)
 		check_all_events(ses, EVENT_FLAG_SYSTEM, 0, 2, "READ ERROR", filename, "FREAD FAILURE");
 		
 		tintin_printf(ses, "#ERROR: #READ {%s}: FREAD FAILURE.", filename);
+
+		free(bufi);
+		free(bufo);
 
 		return ses;
 	}

--- a/src/history.c
+++ b/src/history.c
@@ -157,6 +157,13 @@ DO_HISTORY(history_get)
 		return;
 	}
 
+	if (root->used == 0)
+	{
+		show_error(ses, LIST_COMMAND, "#HISTORY GET: THE HISTORY LIST IS EMPTY.");
+
+		return;
+	}
+
 	arg = get_arg_in_braces(ses, arg, arg2, GET_ONE);
 
 	min = get_number(ses, arg2);

--- a/src/mapper.c
+++ b/src/mapper.c
@@ -289,6 +289,10 @@ int delete_map(struct session *ses)
 	delete_node(ses, LIST_ACTION, ses->map->search->note);
 	delete_node(ses, LIST_ACTION, ses->map->search->terrain);
 
+	free(ses->map->search->arg);
+	free(ses->map->search->exit_list);
+	free(ses->map->search->id);
+
 	free(ses->map->search);
 
 	free(ses->map);

--- a/src/mapper.c
+++ b/src/mapper.c
@@ -317,7 +317,7 @@ struct room_data *create_room(struct session *ses, char *format, ...)
 
 	newroom->vnum = atoi(arg1);
 
-	if (HAS_BIT(ses->map->flags, MAP_FLAG_SYNC) && ses->map->room_list[newroom->vnum] != NULL)
+	if (HAS_BIT(ses->map->flags, MAP_FLAG_SYNC) && newroom->vnum > 0 && newroom->vnum < ses->map->size && ses->map->room_list[newroom->vnum] != NULL)
 	{
 		int vnum = newroom->vnum;
 
@@ -454,6 +454,14 @@ struct exit_data *create_exit(struct session *ses, int vnum, char *format, ...)
 	va_end(args);
 
 	newexit = (struct exit_data *) calloc(1, sizeof(struct exit_data));
+
+	if (vnum <= 0 || vnum >= ses->map->size || ses->map->room_list[vnum] == NULL)
+	{
+		free(newexit);
+
+		pop_call();
+		return NULL;
+	}
 
 	room = ses->map->room_list[vnum];
 

--- a/src/nest.c
+++ b/src/nest.c
@@ -1406,9 +1406,7 @@ struct listnode *add_nest_node(struct listroot *root, char *arg1, char *format, 
 
 	if (*space_out(arg2) == DEFAULT_OPEN)
 	{
-		root = update_nest_root(root, name);
-
-		update_nest_node(root, arg2);
+		update_nest_node(update_nest_root(root, name), arg2);
 
 		node = search_node_list(root, name);
 	}

--- a/src/port.c
+++ b/src/port.c
@@ -358,11 +358,25 @@ void close_port(struct session *ses, struct port_data *buddy, int unlink)
 	end_mccp2(ses, buddy);
 	end_mccp3(ses, buddy);
 
+	if (buddy->msdp_data)
+	{
+		int index;
+
+		for (index = 0 ; index < gtd->msdp_table_size ; index++)
+		{
+			free(buddy->msdp_data[index]->value);
+			free(buddy->msdp_data[index]);
+		}
+		free(buddy->msdp_data);
+	}
+
 	free(buddy->group);
 	free(buddy->ip);
 	free(buddy->name);
 	free(buddy->prefix);
 	free(buddy->color);
+	free(buddy->proxy);
+	free(buddy->ttype);
 
 	free(buddy);
 

--- a/src/regex.c
+++ b/src/regex.c
@@ -123,6 +123,11 @@ int regexp_compare(struct session *ses, pcre2_code *nodepcre, char *str, char *e
 		return FALSE;
 	}
 
+	if (matches > 100)
+	{
+		matches = 100;
+	}
+
 	PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
 
 	memcpy(gtd->match, ovector, matches * 2 * sizeof(PCRE2_SIZE));

--- a/src/scan.c
+++ b/src/scan.c
@@ -493,6 +493,8 @@ DO_SCAN(scan_json)
 	{
 		show_error(ses, LIST_COMMAND, "#SCAN JSON {%s}: ERROR READING FILE.", arg1);
 
+		free(src);
+
 		return ses;
 	}
 

--- a/src/tokenize.c
+++ b/src/tokenize.c
@@ -1318,6 +1318,14 @@ struct session *script_driver(struct session *ses, int list, struct listnode *no
 
 	push_call("script_driver(%p,%d,%p)",ses,list,str);
 
+	if (gtd->script_index + 1 >= STACK_SIZE)
+	{
+		show_error(ses, list, "#ERROR: SCRIPT STACK OVERFLOW, ABORTING (INFINITE RECURSION?).");
+
+		pop_call();
+		return ses;
+	}
+
 	root = push_script_stack(ses, list);
 
 	gtd->level->input += list != LIST_COMMAND;

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -734,6 +734,11 @@ void check_all_highlights(struct session *ses, char *original, char *line)
 					ptl = strstr(ptl, match) + strlen(match);
 				}
 
+				if (ptm == NULL)
+				{
+					break;
+				}
+
 				*ptm = 0;
 
 				get_color_codes(gtd->color_reset, pto, gtd->color_reset, GET_ALL);
@@ -997,6 +1002,11 @@ void check_all_substitutions(struct session *ses, char *original, char *line)
 					ptl = strstr(ptl, match) + strlen(match);
 				}
 
+				if (ptm == NULL)
+				{
+					break;
+				}
+
 				*ptm = 0;
 
 				get_color_codes(gtd->color_reset, pto, gtd->color_reset, GET_ALL);
@@ -1086,6 +1096,11 @@ void check_all_substitutions_multi(struct session *ses, char *original, char *li
 					ptm = strip_vt102_strstr(pto, match, &len);
 
 					ptl = strstr(ptl, match) + strlen(match);
+				}
+
+				if (ptm == NULL)
+				{
+					break;
 				}
 
 				*ptm = 0;

--- a/src/variable.c
+++ b/src/variable.c
@@ -428,6 +428,8 @@ void basetostring(char *str, char *base)
 			tintin_printf2(gtd->ses, "#FORMAT: UNKNOWN BASE CONVERSION {%s}.", base);
 			break;
 	}
+	free(buf);
+
 	pop_call();
 	return;
 }
@@ -482,6 +484,8 @@ void basetostringz(char *str, char *base)
 			tintin_printf2(gtd->ses, "#FORMAT: UNKNOWN BASE CONVERSION {%s}.", base);
 			break;
 	}
+	free(buf);
+
 	pop_call();
 	return;
 }


### PR DESCRIPTION
## Summary

This PR fixes a set of memory-safety bugs (out-of-bounds accesses, a buffer underflow, NULL dereferences, an off-by-one) and memory leaks found while auditing the client. Each fix is an isolated, minimal commit that preserves existing behaviour on valid input; the tree builds cleanly with no new warnings.

Most of these are defensive hardening — under normal use with a well-behaved server they rarely fire — but a few are reachable through ordinary user actions (a recursive alias, `#history get` on empty history, automapper reloads). An impact assessment is included below to help with review prioritisation.

## Bug fixes

| Fix | What it does | Likelihood in normal use |
|-----|-------------|--------------------------|
| **Script recursion overflow** | `script_driver()` now aborts with an error instead of overrunning `script_stack[STACK_SIZE]` when nesting goes too deep | **Moderate** — an accidental self-recursive alias/function (`#alias {a} {a}`) is a common mistake |
| **`#history get` empty-list OOB** | Rejects the command when the history list is empty instead of indexing `list[-1]` (from `URANGE(0, min, used-1)` = -1) | **Low–Moderate** — running `#history get` before any history exists is a plausible, benign trigger |
| **`add_nest_node` NULL deref** | Mirrors `set_nest_node()`: keeps `root` intact so the node lookup succeeds, avoiding a NULL deref of `node->shots` under `#line oneshot`/`multishot` on a nested `{...}` variable | **Low** — needs a specific but legitimate feature combination |
| **`strip_vt102_strstr` NULL** | Breaks out of the highlight/substitute loop when the match can't be located in the colour-bearing copy instead of writing through NULL | **Low** — possible with ordinary colour codes plus user highlights/subs; the position desync is uncommon |
| **`grid_val` mouse index OOB** | Uses zero-based `(char_row-1)/(char_col-1)` so the 3×3 grid index stays within `grid_val[9]` at a cell's bottom/right edge | **Low** — only affects pixel-resolution mouse mode, but fires readily within it |
| **`regexp_compare` off-by-one** | Clamps the match count to 100 so `gtd->vars/cmds/args[100]` are never written/read out of bounds (ovector was sized 101) | **Very low** — needs a pattern with ~100 capture groups |
| **`get_chat_commands` underflow** | Bounds the trailing-whitespace trim so it can't walk before the start of the buffer on an empty command payload | **Very low** — needs an empty peer command over chat |
| **`create_room`/`create_exit` OOB** | Range-checks file-supplied room vnums before indexing `room_list[]` (in `MAP SYNC` and on exit creation) | **Very low** — only a corrupt/hand-edited `.map` file triggers it |

## Memory-leak fixes

Rated by how commonly the leaking path runs in normal use:

| Fix | What leaked | Frequency in normal use |
|-----|-------------|-------------------------|
| **`delete_map`** | `search->arg`, `search->exit_list`, `search->id` on every map teardown | **Moderate** — recurs for automapper users who reload maps (`#map read`/`create`) |
| **`basetostring`/`basetostringz`** | The working buffer on every `#format` base-decode (the encode siblings already free it) | **Low** — niche command, but leaks reliably each call |
| **`close_port`** | `msdp_data` array, `proxy`, `ttype` when a hosted `#port` client disconnects | **Very low** — only when running as a server; then per-disconnect |
| **`read_file` error paths** | `bufi`/`bufo` on an empty/unreadable file (valid reads already free) | **Very low** — only on read errors |
| **`close_chat`** | `file_name` and an open `file_pt` if a file transfer is interrupted by disconnect | **Very low** — chat + file transfer + interruption |
| **`scan_json`** | The `src` buffer on a short/failed read | **Very low** — niche command plus an error path |

## Testing

Builds cleanly (`./configure && make`) with no new warnings. Each change is scoped to preserve existing behaviour on valid input; guards were added only where a value can legitimately be NULL/out-of-range, and freed memory was verified to be owned and no longer referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
