### PR TITLE
Two small hot-path performance fixes (regex match_data reuse, vt102 strip)

### DIFF
--- a/src/regex.c
+++ b/src/regex.c
@@ -108,7 +108,12 @@ int regexp_compare(struct session *ses, pcre2_code *nodepcre, char *str, char *e
 		return FALSE;
 	}
 
-	pcre2_match_data *match_data = pcre2_match_data_create(101, NULL);
+	static pcre2_match_data *match_data = NULL;
+
+	if (match_data == NULL)
+	{
+		match_data = pcre2_match_data_create(101, NULL);
+	}
 
 	matches = pcre2_match(regex, (PCRE2_SPTR) str, strlen(str), 0, 0, match_data, NULL);
 
@@ -118,7 +123,6 @@ int regexp_compare(struct session *ses, pcre2_code *nodepcre, char *str, char *e
 		{
 			pcre2_code_free(regex);
 		}
-		pcre2_match_data_free(match_data);
 
 		return FALSE;
 	}
@@ -126,8 +130,6 @@ int regexp_compare(struct session *ses, pcre2_code *nodepcre, char *str, char *e
 	PCRE2_SIZE *ovector = pcre2_get_ovector_pointer(match_data);
 
 	memcpy(gtd->match, ovector, matches * 2 * sizeof(PCRE2_SIZE));
-
-	pcre2_match_data_free(match_data);
 
 	// REGEX_FLAG_FIX handles %1 to %99 usage. Backward compatible.
 

--- a/src/vt102.c
+++ b/src/vt102.c
@@ -586,15 +586,16 @@ int find_secure_color_code(char *str)
 int strip_vt102_codes(char *str, char *buf)
 {
 	char *pti, *pto;
+	int skip;
 
 	pti = (char *) str;
 	pto = (char *) buf;
 
 	while (*pti)
 	{
-		while (skip_vt102_codes(pti))
+		while ((skip = skip_vt102_codes(pti)))
 		{
-			pti += skip_vt102_codes(pti);
+			pti += skip;
 		}
 
 		if (*pti)


### PR DESCRIPTION
## Summary

Two small, self-contained performance fixes on the per-line input hot path. Both are pure changes with no behavioural impact, each a few lines, and neither adds any dependency or platform requirement. They were selected from a wider list specifically because they are low-risk, universally applicable, and have a clear payoff — larger structural wins (pattern-translation caching, word-wrap sharing, JIT, telnet-loop bulk copies) were deliberately left out as too invasive, platform-dependent, or uncertain.

| # | Fix | Location | Payoff | Users affected | Complexity |
|---|-----|----------|--------|----------------|------------|
| 1 | **Reuse a single PCRE2 `match_data`** instead of `pcre2_match_data_create`/`_free` on every match attempt | `regex.c` (`regexp_compare`) | **Medium** — removes a heap alloc+free per line × per trigger | Anyone using triggers/aliases/highlights/substitutes (essentially all active users) | **Low** — allocate one shared `match_data` on first use; drop the two `free`s |
| 2 | **Evaluate `skip_vt102_codes` once per escape** instead of twice (loop condition + body) | `vt102.c` (`strip_vt102_codes`) | **Small–Medium** — halves escape-code classification in a function that runs on every line and on the whole output buffer | **All users** (any colour codes; runs even with zero triggers) | **Trivial** — cache the returned length |

## Why these are safe

- **#1:** `pcre2_match` overwrites the match-data ovector on each call, and `regexp_compare` copies the result into `gtd->match` immediately after the call returns, before any recursion — so a single reused block is correct. It is sized for 101 captures (unchanged) and lives for the process lifetime like other one-time allocations.
- **#2:** `skip_vt102_codes` is a pure function of its argument, so caching its return value is behaviourally identical.

## Testing

Builds cleanly (`./configure && make`) with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
