### PR TITLE
Skip re-substituting a plain variable name

### DIFF
--- a/src/nest.c
+++ b/src/nest.c
@@ -774,6 +774,8 @@ int get_nest_size_val(struct listroot *root, char *variable, char **result)
 	return 0;
 }
 
+// variable can be the caller's own name buffer, so don't write to it.
+
 struct listnode *get_nest_node_key(struct listroot *root, char *variable, char **result, int def)
 {
 	struct listnode *node;
@@ -812,6 +814,8 @@ struct listnode *get_nest_node_key(struct listroot *root, char *variable, char *
 	return NULL;
 }
 
+// variable can be the caller's own name buffer, so don't write to it.
+
 struct listnode *get_nest_node_val(struct listroot *root, char *variable, char **result, int def)
 {
 	struct listnode *node;
@@ -849,6 +853,8 @@ struct listnode *get_nest_node_val(struct listroot *root, char *variable, char *
 	}
 	return NULL;
 }
+
+// variable can be the caller's own name buffer, so don't write to it.
 
 int get_nest_index(struct listroot *root, char *variable, char **result, int def)
 {

--- a/src/substitute.c
+++ b/src/substitute.c
@@ -1364,18 +1364,23 @@ int substitute(struct session *ses, char *string, char *result, int flags)
 
 					if (brace == FALSE)
 					{
-						pti = get_arg_at_brackets(ses, &pti[i], temp + strlen(temp));
+						pti = get_arg_at_brackets(ses, &pti[i], ptt);
 					}
 					else
 					{
 						pti = get_arg_in_braces(ses, &pti[i], temp, GET_ONE);
 					}
 
-					substitute(ses, temp, buf, flags_neol);
+					// A plain name has nothing to substitute.
+
+					if (brace || *ptt)
+					{
+						substitute(ses, temp, buf, flags_neol);
+					}
 
 					str = str_dup("");
 
-					get_nest_node_key(root, buf, &str, brace);
+					get_nest_node_key(root, brace || *ptt ? buf : temp, &str, brace);
 
 					substitute(ses, str, pto, flags_neol - SUB_VAR);
 
@@ -1470,18 +1475,23 @@ int substitute(struct session *ses, char *string, char *result, int flags)
 
 					if (brace == FALSE)
 					{
-						pti = get_arg_at_brackets(ses, &pti[i], temp + strlen(temp));
+						pti = get_arg_at_brackets(ses, &pti[i], ptt);
 					}
 					else
 					{
 						pti = get_arg_in_braces(ses, &pti[i], temp, GET_ONE);
 					}
 
-					substitute(ses, temp, buf, flags_neol);
+					// A plain name has nothing to substitute.
+
+					if (brace || *ptt)
+					{
+						substitute(ses, temp, buf, flags_neol);
+					}
 
 					str = str_dup("");
 
-					get_nest_node_val(root, buf, &str, brace);
+					get_nest_node_val(root, brace || *ptt ? buf : temp, &str, brace);
 
 					substitute(ses, str, pto, flags_neol - SUB_VAR);
 
@@ -1604,18 +1614,23 @@ int substitute(struct session *ses, char *string, char *result, int flags)
 
 					if (brace == FALSE)
 					{
-						pti = get_arg_at_brackets(ses, &pti[i], temp + strlen(temp));
+						pti = get_arg_at_brackets(ses, &pti[i], ptt);
 					}
 					else
 					{
 						pti = get_arg_in_braces(ses, &pti[i], temp, GET_ONE);
 					}
 
-					substitute(ses, temp, buf, flags_neol);
+					// A plain name has nothing to substitute.
+
+					if (brace || *ptt)
+					{
+						substitute(ses, temp, buf, flags_neol);
+					}
 
 					str = str_dup("");
 
-					get_nest_index(root, buf, &str, brace);
+					get_nest_index(root, brace || *ptt ? buf : temp, &str, brace);
 
 					substitute(ses, str, pto, flags_neol - SUB_VAR);
 


### PR DESCRIPTION
## Summary

The `$`, `*` and `&` handlers in `substitute()` build the variable name into `temp`, then run it back through `substitute()` before looking it up. On the unbraced path `temp` is built by

```c
for (ptt = temp ; is_alnum(pti[i]) || pti[i] == '_' ; i++)
```

so it holds only characters from `[0-9A-Za-z_]`, and `get_arg_at_brackets()` then appends a bracket index or nothing.

`substitute()` acts on `{ } @ * & % < $ \ NUL ESC` and newline — **none of which can appear in such a name**. So when no index was appended, that recursive call is a pure copy. This guards it and hands the name straight to the lookup:

```diff
-					substitute(ses, temp, buf, flags_neol);
+					// A plain name has nothing to substitute.
+
+					if (brace || *ptt)
+					{
+						substitute(ses, temp, buf, flags_neol);
+					}
 
 					str = str_dup("");
 
-					get_nest_node_key(root, buf, &str, brace);
+					get_nest_node_key(root, brace || *ptt ? buf : temp, &str, brace);
```

The braced form and any bracket index still go through `substitute()`, since either can contain variables to expand. The guard is written `brace || *ptt` so the short circuit keeps it from reading `ptt` on the braced path, where it is not set. `*ptt == 0` is a sound "nothing appended" test because `get_arg_at_brackets()` writes `*pto = 0` and returns when its input does not start with `[`.

**Two files, 30 insertions, 9 deletions.**

## Correctness

The character sets were checked against the real `character_table[]` rather than by reading the switch: `is_alnum()` accepts exactly **62** bytes (`0-9`, `A-Z`, `a-z`), plus `_` added by the loop condition. Intersecting that with the characters `substitute()` acts on gives **no overlap**, so a plain name is copied verbatim — which is why passing it directly is equivalent.

Passing `temp` rather than the substituted copy means `get_nest_node_key()`, `get_nest_node_val()` and `get_nest_index()` now receive the caller's own name buffer, so a comment records that they must not write to it. They have no other callers, and the chain below them — `get_nest_size_*`, `search_nest_node`, `search_base_node`, `search_nest_index`, `delete_nest_node`, and the `get_arg_to_brackets`/`get_arg_in_brackets` parsers — only ever reads the name; those parsers write solely through their `result` pointer.

`substitute()` itself has no side effects beyond writing its result: its `push_call`/`pop_call` are balanced, it releases its own stack slots, it never writes through its input pointer, and its return value is discarded at these call sites.

## Benchmarks

Median of seven runs: **4.4 ns saved per variable reference** (range 4.3 to 4.8).

| | ns per reference |
|---|---|
| Current: recursive `substitute()` | 4.8 |
| Patched: name passed directly | 0.4 |

The harness models `substitute()`'s fixed overhead — the `push_call`, two `str_alloc_stack` grabs, the character loop and the `pop_call` — so the real saving is a little larger, since the live function also runs its per-character EUC check and switch.

Worth noting for anyone reviewing the shape of the patch: **copying the name into `buf` instead of skipping the call saves nothing** (5.1 vs 4.8 ns) — the copy costs about as much as the call it would replace. Only handing the name straight through is worth doing, which is why the call site selects between `buf` and `temp` rather than doing a `strcpy`.

The change also replaces `temp + strlen(temp)` with `ptt`, which already points at that position. No figure is quoted for that: it was benchmarked, but the compiler elided the `strlen` in the harness, so the measurement was not meaningful.

## Manual verification

Two binaries built from trees differing only in this patch, driven through **35 expansion cases**. Output was **byte identical** — same length, same MD5, empty diff.

| Cases | Coverage | Path |
|---|---|---|
| 01–07 | plain `$var` / `*var` / `&var`, underscore and digit names, undefined names | **new fast path** |
| 08–10 | braced `${var}` | `substitute()` |
| 11–19 | bracket indices, `[]` size queries | `substitute()` |
| 14–16, 33 | bracket index holding a variable (`$tbl[$key]`, `$tbl[${key}]`) | `substitute()` |
| 20–23 | nested `$nest[x][y]` | multi level |
| 24–28 | missing key, regex query `%*`, ellipsis `1..2` | `get_nest_size_*` |
| 29–31 | escaped `$$var`, `**var`, `&&var` | escape handling |
| 32, 34–35 | mixed and adjacent expansions on one line | loop re-entry |

Cases 14–16 and 33 are the load bearing ones: a bracket index containing `$key` requires the `substitute()` call, and all four resolved correctly (`$tbl[$key]` → `2`, `*tbl[$key]` → `beta`). Cases 05–07 matter too, since the undefined-name fallback reads the name buffer *after* the lookup to build `$nosuchvar`, and returned the correct literals.

## Testing

Builds cleanly; `substitute.c` and `nest.c` both compile with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
