### PR TITLE
Guard the vt102 scan at seven more per-character call sites

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -244,7 +244,7 @@ void add_line_buffer(struct session *ses, char *line, int prompt)
 			continue;
 		}
 
-		skip = skip_vt102_codes(pti);
+		skip = (unsigned char) *pti < 32 || (unsigned char) *pti == 127 ? skip_vt102_codes(pti) : 0;
 
 		if (SCROLL(ses))
 		{

--- a/src/text.c
+++ b/src/text.c
@@ -191,7 +191,7 @@ int word_wrap(struct session *ses, char *textin, char *textout, int flags, int *
 
 	while (*pti && pto - textout < BUFFER_SIZE)
 	{
-		skip = skip_vt102_codes(pti);
+		skip = (unsigned char) *pti < 32 || (unsigned char) *pti == 127 ? skip_vt102_codes(pti) : 0;
 
 		if (skip)
 		{
@@ -382,7 +382,7 @@ int word_wrap_split(struct session *ses, char *textin, char *textout, int wrap, 
 			return 1;
 		}
 
-		skip = skip_vt102_codes(pti);
+		skip = (unsigned char) *pti < 32 || (unsigned char) *pti == 127 ? skip_vt102_codes(pti) : 0;
 
 		if (skip)
 		{

--- a/src/vt102.c
+++ b/src/vt102.c
@@ -594,7 +594,7 @@ int strip_vt102_codes(char *str, char *buf)
 
 	while (*pti)
 	{
-		while ((skip = skip_vt102_codes(pti)))
+		while (((unsigned char) *pti < 32 || (unsigned char) *pti == 127) && (skip = skip_vt102_codes(pti)))
 		{
 			pti += skip;
 		}
@@ -669,7 +669,7 @@ char *strip_vt102_strstr(char *str, char *buf, int *len)
 
 	while (*pts)
 	{
-		while ((skip = skip_vt102_codes(pts)))
+		while (((unsigned char) *pts < 32 || (unsigned char) *pts == 127) && (skip = skip_vt102_codes(pts)))
 		{
 			pts += skip;
 		}
@@ -694,7 +694,7 @@ char *strip_vt102_strstr(char *str, char *buf, int *len)
 				return pts;
 			}
 
-			while ((skip = skip_vt102_codes(pti)))
+			while (((unsigned char) *pti < 32 || (unsigned char) *pti == 127) && (skip = skip_vt102_codes(pti)))
 			{
 				pti += skip;
 			}
@@ -1020,7 +1020,7 @@ int strip_vt102_strlen(struct session *ses, char *str)
 
 	while (*pti)
 	{
-		size = skip_vt102_codes(pti);
+		size = (unsigned char) *pti < 32 || (unsigned char) *pti == 127 ? skip_vt102_codes(pti) : 0;
 
 		if (size == 0)
 		{


### PR DESCRIPTION
## Summary

This applies the exact change from #281 to seven more call sites.

#281 guarded the `skip_vt102_codes()` call inside `get_vt102_width()`, on the grounds that the scan can only return non-zero when the byte *begins* a vt102 code, and every case in its switch is a control character, ESC, or DEL:

```
7, 8, 11, 12, 13, 14, 15, 17, 19, 24, 26, 27, 28, 127
```

Everything else falls through to `default: return 0`, so on ordinary text the call is pure overhead. The same reasoning applies unchanged to the loops that walk a string a byte at a time — they were simply not in scope for that PR.

**7 lines changed across 3 files.** No API change, no header change, no new invariant, no behaviour change.

## The change

Two shapes. Where the result is assigned and then tested:

```diff
-		skip = skip_vt102_codes(pti);
+		skip = (unsigned char) *pti < 32 || (unsigned char) *pti == 127 ? skip_vt102_codes(pti) : 0;
```

And where it drives a loop, short-circuited in the condition so the guard is not re-evaluated pointlessly once a code is found:

```diff
-		while ((skip = skip_vt102_codes(pti)))
+		while (((unsigned char) *pti < 32 || (unsigned char) *pti == 127) && (skip = skip_vt102_codes(pti)))
```

The predicate is character-for-character the one now in `get_vt102_width()`, including the `(unsigned char)` casts — which matter, since `char` is signed on some platforms and without them bytes `0x80`-`0xFF` would compare below 32 and defeat the guard.

## Why these seven sites

The remaining call sites are in `draw.c`, `string.c`, `variable.c` and `substitute.c`. I left them alone deliberately: they are cold, and guarding them would add diff for no measurable return. I instrumented all of them with counters over a line-processing workload driving actions, highlights, substitutes and gags through `#scan txt` to decide.

| Site | Function | Share of calls | Why it is worth guarding |
|---|---|---|---|
| `vt102.c:597` | `strip_vt102_codes` | 33.0% | The general-purpose stripper, 28 call sites — events, actions, logging, plain copies |
| `buffer.c:247` | `add_line_buffer` | 32.6% | Runs for **every line** entering the scrollback |
| `text.c:385` | `word_wrap_split` | 30.7% | Runs for **every line** wrapped into the buffer |
| `vt102.c:1023` | `strip_vt102_strlen` | 3.3% | Display length; 12 callers, including the scrollback, the input line and `screen.c` |
| `text.c:194` | `word_wrap` | 0.25% | Understated — see below |
| `vt102.c:697` | `strip_vt102_strstr` | ~0% | Understated — see below |
| `vt102.c:672` | `strip_vt102_strstr` | ~0% | Understated — see below |

Those three low numbers are artifacts of driving the workload through `#scan txt` rather than a live session, and I would rather flag that than quote them as if they settled the matter:

- **`word_wrap()` (text.c:194)** is called from `print_line()`. That is the *display* path — it runs for every line a user actually sees. A scan-driven workload suppresses most output and reaches `word_wrap_split()` instead, so the counter badly under-represents it. On a real session this belongs with the top three.

- **`strip_vt102_strstr()` (vt102.c:672 and :697)** has three callers, all in `trigger.c` — it is the highlight matcher. My workload registers only a handful of highlights; anyone running a normal highlight list hits this on every matching line, and both loops are per-character.

One site is worth calling out specifically. **`strip_vt102_strlen()` (vt102.c:1023) is not covered by #281**: its `size == 0` branch calls `get_ascii_width()` / `get_utf8_width()` directly rather than going through `get_vt102_width()`, so the guard you merged never reaches it. It is the hottest remaining unguarded path.

I also excluded `strip_non_vt102_codes()` (vt102.c:646) even though it fits the pattern, because its only caller is the gag path in `net.c` and my workload never reached it. I would rather not include a site I could not measure.

## Measurements

arm64, `-O3`, 25 interleaved runs of each build, on the line-processing workload above:

| Build | Before | After | Best | Mean |
|---|---|---|---|---|
| `-O3` | 6370 µs | 5759 µs | **−9.4%** | **−9.6%** |
| `-O3 -flto` | 6011 µs | 5407 µs | **−9.5%** | **−10.0%** |

I built it a second time with `-flto` specifically to check whether cross-translation-unit inlining would absorb the win, since these callers live in different objects from `vt102.c`. It does not — the gain is if anything slightly larger.

That is because the guard does not just save a call. `skip_vt102_codes()` is 620 bytes and 155 instructions with loops in several switch arms, well past any inline threshold, and what the guard skips is the whole prologue and switch dispatch. Each of these loops has *just* tested the same byte in its own `while (*p)` condition, so the lead byte is already in a register and the guard costs one compare and branch against work the callee would otherwise redo from memory.

## Verification

Output is **byte identical** to an unpatched build — 190 KB over a 446-line workload covering:

- every lead byte from 1 to 255, both leading and embedded mid-line
- ANSI, CSI, OSC and DCS sequences, and the byte-28 `HTML_OPEN` arm
- valid UTF-8, deliberately truncated UTF-8, and double-width CJK
- tabs, DEL, and the full set of handled control characters
- lines forced to wrap at nine different widths, ASCII and CJK and coloured
- highlights, substitutes, gags and actions firing throughout

I also instrumented the patched build to confirm every one of the seven guarded sites was actually reached by that workload rather than assuming it — the hottest at 142k calls, the thinnest at 285 — so the byte-identical result is not vacuous for any of them.

The guard is the exact complement of the switch's `default:` arm, so the equivalence is structural rather than empirical: for any byte the guard rejects, `skip_vt102_codes()` would have returned 0.
