### PR TITLE
Return early from get_vt102_width for printable ascii

### DIFF
--- a/src/vt102.c
+++ b/src/vt102.c
@@ -442,6 +442,13 @@ int skip_all_vt102_codes_non_graph(char *str)
 
 int get_vt102_width(struct session *ses, char *str, int *str_len)
 {
+	if ((unsigned char) *str > 31 && (unsigned char) *str < 127)
+	{
+		*str_len = 1;
+
+		return 1;
+	}
+
 	*str_len = 0;
 
 	if (*str)


### PR DESCRIPTION
## Summary

A follow-on to #281, on the same function.

#281 stopped printable bytes paying for the `skip_vt102_codes()` scan in `get_vt102_width()`. What those bytes still pay for is the charset dispatch below it — a test for EUC, a test for UTF-8, then a call into `get_euc_width()`, `get_utf8_width()` or `get_ascii_width()`.

For a byte whose value falls between 32 and 126 all three return the same answer — one byte long, one column wide — so the dispatch cannot change the result:

| | for byte values 32-126 |
|---|---|
| `get_ascii_width()` | `utf8_width_table[32..126]` is uniformly `1`, so width 1, returns 1 |
| `get_utf8_width()` | reads the same table, takes the `size <= 1` early return, so width 1, returns 1 |
| `get_euc_width()` | every BIG5, CP949 and GBK1 branch requires the lead byte above 128, so all three fall through to width 1, return 1 |

So answer those bytes directly:

```diff
 int get_vt102_width(struct session *ses, char *str, int *str_len)
 {
+	if ((unsigned char) *str > 31 && (unsigned char) *str < 127)
+	{
+		*str_len = 1;
+
+		return 1;
+	}
+
 	*str_len = 0;
```

**Seven lines added, nothing removed**, and the guard from #281 is untouched. The range excludes 127, which is left to the existing path since DEL is a vt102 code, and excludes byte 0, which still falls through to the trailing `return 0`.

`get_vt102_width()` is called per character from `word_wrap()`, `word_wrap_split()`, `strip_vt102_width()`, `screen.c`, `string.c` and twelve places in `cursor.c`, so this is the per-character display and input editing path. On the workload below the new branch is taken 96.9% of the time.

## What this assumes

The fast path assumes that a byte with a value from 32 to 126 always represents a character one byte long and one column wide, whatever charset is active. That holds for all twelve charsets supported here: UTF-8 by design, BIG5, GBK1 and CP949 because every one of their branches requires a lead byte above 128, and the eight single byte conversions trivially.

It is also not a new assumption. `word_wrap()` and `word_wrap_split()` already find word breaks by testing raw bytes against `' '` at text.c:246 and text.c:444 and `skip_vt102_codes()` already dispatches on a literal `'['`. Any encoding in which byte 0x20 or 0x5B could be the trailing half of a multibyte character would break wrapping and vt102 parsing well before it reached `get_vt102_width()`.

The encodings that would genuinely violate it are the stateful escape shifted ones such as ISO-2022-JP, where ASCII range bytes become double byte after `ESC $ B`, and wide unit ones such as UTF-16. Neither could be added as another branch in `get_euc_width()`; both would need the byte oriented model reworked throughout. So this leans on something the codebase already depends on everywhere rather than introducing a new constraint.

## Measurements

Rebased onto current development, so these are re-measured against a tree that already contains #291.

arm64, `-O3 -flto`, on a line-processing workload driving actions, highlights, substitutes and gags through `#scan txt`. 25 runs of each build, execution order alternated between reps, no errors on either build.

| | best | mean |
|---|---|---|
| this patch, on current development | **−5.6%** | **−4.5%** |

I checked whether `-flto` absorbs this the way it would a plain duplicate-call removal, and it does not — the patched and unpatched binaries differ, and the gain above is measured with LTO on. That is expected: collapsing this would require proving that `get_euc_width()`, `get_utf8_width()` and `get_ascii_width()` all return one byte and one column for this range, which runs through a table lookup in another translation unit.

## Verification

Equivalence is checked exhaustively rather than sampled, and re-run against current development. A harness linked against the real `get_euc_width()`, `get_utf8_width()`, `get_ascii_width()` and `skip_vt102_codes()` compared this function against a copy of the previous implementation across every lead byte from 0 to 255, twenty tails covering ESC, CSI, OSC and DCS sequences, valid and truncated UTF-8, EUC lead pairs and bare control bytes, in six charset configurations spanning ascii, utf8, big5, gbk1 and cp949. **All 30720 cases agreed** on both the returned size and the width written through `str_len`.

Nothing observable is skipped: `skip_vt102_codes()` is read-only and the width helpers have no side effects here. The `"debug: unknown charset"` line in `get_euc_width()` is unreachable from this path, since `CHARSET_FLAG_EUC` is `BIG5|GBK1|CP949` and `HAS_BIT` tests any bit.

Full program output is byte identical between the two builds over a workload covering every lead byte both leading and embedded, ANSI/CSI/OSC/DCS, truncated UTF-8, double width CJK, tabs, DEL, nine wrap widths, and live highlights, substitutes and gags. Instrumentation confirmed the new branch is actually taken by that workload rather than assumed, 13619 times against 4022 for the existing path.
