### PR TITLE
Call skip_vt102_codes once per iteration in string_raw_str_len

### DIFF
--- a/src/variable.c
+++ b/src/variable.c
@@ -1169,7 +1169,7 @@ int string_str_str_len(struct session *ses, char *str, int start, int end)
 
 int string_raw_str_len(struct session *ses, char *str, int raw_start, int raw_end)
 {
-	int raw_cnt, ret_cnt, tot_len, width, col_len;
+	int raw_cnt, ret_cnt, tot_len, width, col_len, skip;
 
 	raw_cnt = raw_start;
 	ret_cnt = 0;
@@ -1184,9 +1184,11 @@ int string_raw_str_len(struct session *ses, char *str, int raw_start, int raw_en
 
 		if ((unsigned char) str[raw_cnt] < 32 || str[raw_cnt] == 127)
 		{
-			if (skip_vt102_codes(&str[raw_cnt]))
+			skip = skip_vt102_codes(&str[raw_cnt]);
+
+			if (skip)
 			{
-				raw_cnt += skip_vt102_codes(&str[raw_cnt]);
+				raw_cnt += skip;
 
 				continue;
 			}


### PR DESCRIPTION
## Summary

Rebased onto current development. This is a consistency fix.

`string_raw_str_len()` calls `skip_vt102_codes()` twice on the same position — once in the `if` to use as a boolean, then again in the body to use as a value:

```c
		if ((unsigned char) str[raw_cnt] < 32 || str[raw_cnt] == 127)
		{
			if (skip_vt102_codes(&str[raw_cnt]))
			{
				raw_cnt += skip_vt102_codes(&str[raw_cnt]);

				continue;
			}
		}
```

Capture it in a local and test that:

```diff
-	int raw_cnt, ret_cnt, tot_len, width, col_len;
+	int raw_cnt, ret_cnt, tot_len, width, col_len, skip;
 
 		if ((unsigned char) str[raw_cnt] < 32 || str[raw_cnt] == 127)
 		{
-			if (skip_vt102_codes(&str[raw_cnt]))
+			skip = skip_vt102_codes(&str[raw_cnt]);
+
+			if (skip)
 			{
-				raw_cnt += skip_vt102_codes(&str[raw_cnt]);
+				raw_cnt += skip;
 
 				continue;
 			}
 		}
```

## Why this form

This is character for character the shape you used at **variable.c:1004** in `string_str_raw_len()`, and again at variable.c:1096 in `string_str_str_len()` — the two sibling functions immediately above this one in the same file:

```c
			skip = skip_vt102_codes(&str[raw_cnt]);

			if (skip)
			{
```

With this applied, all three `string_*_len()` loops in `variable.c` read identically.

It is also the tree-wide convention. Of the thirteen places that call `skip_vt102_codes()` and use the result, twelve assign it to a local first — `draw.c:945`, `string.c:79`, `:127`, `:159`, `:218`, `:271`, `text.c:196`, `:390`, `variable.c:1004`, `:1096`, `vt102.c:296`, `:451`. **variable.c:1187 is the only one left that calls it directly inside an `if`**, so this removes the last exception.

## Retracting the performance claim I opened this with

The original version of this PR quoted about −18% on a colour-heavy `#format` workload. **That does not survive `-flto`, which you have since made the default, and I am withdrawing it.** With LTO on, clang collapses the two calls itself — patched and unpatched binaries come out byte identical, so the gain there is exactly zero. GCC still emits the duplicate call, but I could not measure a reliable difference on it, so I am not going to claim one.

The only configuration where the number held up was a non-LTO build against a deliberately pathological subject, which is not a case worth optimising for. The reason to take this is that it makes the file consistent, not that it makes it faster.

## Verification

Both builds compiled **without** `-flto`, so the change is actually present rather than optimised away. Output is byte identical over a 446 line workload covering every lead byte from 1 to 255 both leading and embedded, ANSI and CSI and OSC and DCS sequences, valid and truncated UTF-8, double width CJK, tabs, DEL, lines forced to wrap at nine widths, and live highlights, substitutes, gags and actions.
