### PR TITLE
Bound the memset in indent_one, and drop the unused IS_CTRL macro

### DIFF
--- a/src/tintin.h
+++ b/src/tintin.h
@@ -1038,7 +1038,6 @@ enum operators
 
 #define VERBATIM(ses)             (gtd->level->verbatim || (gtd->level->input == 0 && (HAS_BIT((ses)->config_flags, CONFIG_FLAG_VERBATIM) || HAS_BIT(gtd->flags, TINTIN_FLAG_CHILDLOCK))))
 
-#define IS_CTRL(c)                ((unsigned char) c < 32 || c == 127)
 
 
 /*

--- a/src/utils.c
+++ b/src/utils.c
@@ -454,9 +454,11 @@ char *indent_one(int len)
 
 	cnt = (cnt + 1) % 10;
 
-	memset(outbuf[cnt], ' ', UMAX(1, len));
+	len = URANGE(0, len, STACK_SIZE - 1);
 
-	outbuf[cnt][len < STACK_SIZE ? len : STACK_SIZE - 1] = 0;
+	memset(outbuf[cnt], ' ', len);
+
+	outbuf[cnt][len] = 0;
 
 	return outbuf[cnt];
 }


### PR DESCRIPTION
## Summary

`indent_one()` writes into a fixed 1000 byte row:

```c
	static char outbuf[10][STACK_SIZE];

	memset(outbuf[cnt], ' ', UMAX(1, len));

	outbuf[cnt][len < STACK_SIZE ? len : STACK_SIZE - 1] = 0;
```

The terminator is clamped to `STACK_SIZE - 1`, but the `memset` above it is not — so any `len` of 1000 or more writes past the end of the row.

```diff
-	memset(outbuf[cnt], ' ', UMAX(1, len));
+	len = URANGE(0, len, STACK_SIZE - 1);
 
-	outbuf[cnt][len < STACK_SIZE ? len : STACK_SIZE - 1] = 0;
+	memset(outbuf[cnt], ' ', len);
+
+	outbuf[cnt][len] = 0;
```

Clamping `len` once up front keeps the two in agreement.

**This is not a regression.** The previous version wrote the terminator out of bounds as well, so 2.02.62 already improved on it — the `memset` is simply the half that was missed.

## Reproducing it

All five `draw.c` call sites pass `top_col - 1`, and `get_col_index()` clamps `top_col` to the screen width, so this needs a terminal wider than 1000 columns:

```
#draw scroll box 1 1100 5 1200 text
```

On a 1200 column terminal that calls `indent_one(1099)` and memsets 99 bytes past the row. The `scroll` flag matters — the plain variants take a different path and never reach `indent_one()`. I instrumented the function to confirm the value rather than inferring it from the source.

Worth noting ASAN does **not** catch this: `outbuf` is a single 10 KB object, so a 99 byte overrun of row `cnt` lands inside row `cnt + 1` and only escapes the object when `cnt == 9`.

## Behaviour is unchanged

| `len` | before | after |
|---|---|---|
| 0 | empty string | empty string |
| 1-999 | *n* spaces | *n* spaces |
| >= 1000 | **writes *n* bytes**, then truncates to 999 spaces | 999 spaces |
| < 0 | **negative index write** | empty string |

The truncation the old terminator clamp produced is preserved exactly; only the out of bounds write goes away. It also removes the negative index case, though no current caller can produce one.

Verified byte identical against an unpatched build over the five draw types that reach this path, on a 1200 column terminal where the overflow fires and on a 100 column terminal where it does not.

## The second change

`IS_CTRL` was added to tintin.h in 2.02.62 and is not referenced anywhere in the tree. Its parameter is also unparenthesised, so `IS_CTRL(a + b)` would expand to `((unsigned char) a + b < 32 || a + b == 127)` and evaluate the argument twice. Confirmed unused both by a repo wide search and by building with it deleted.
