### PR TITLE
Add GitHub Actions CI: build checks on Linux and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpcre2-dev libgnutls28-dev libz-dev libzstd-dev
+
+      - name: Configure
+        working-directory: src
+        run: ./configure
+
+      - name: Build
+        working-directory: src
+        env:
+          # make implicit function declarations an error on gcc too,
+          # so the Linux job catches what is a hard error on macOS/clang
+          CFLAGS: -Werror=implicit-function-declaration
+        run: make -j$(nproc)
+
+      - name: Smoke test
+        working-directory: src
+        run: |
+          out=$(./tt++ -V 2>&1 || true)
+          echo "$out" | grep -q 'TinTin++'
+
+  macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: brew install pcre2 gnutls zstd
+
+      - name: Configure
+        working-directory: src
+        run: |
+          # Homebrew on Apple Silicon lives under /opt/homebrew, which
+          # neither configure nor clang search by default
+          BREW=$(brew --prefix)
+          ./configure --includedir=$BREW/include \
+                      CPPFLAGS=-I$BREW/include \
+                      LDFLAGS=-L$BREW/lib
+
+      - name: Build
+        working-directory: src
+        run: make -j$(sysctl -n hw.ncpu)
+
+      - name: Smoke test
+        working-directory: src
+        run: |
+          out=$(./tt++ -V 2>&1 || true)
+          echo "$out" | grep -q 'TinTin++'


### PR DESCRIPTION
This adds a single workflow with two jobs that build tintin on every push and pull request: one on Ubuntu/gcc, one on macOS/clang (Apple Silicon). There's no test suite to run, so each job answers just two questions: does it compile, and does the binary start (`tt++ -V`, checked by grepping the version banner — `-V` doesn't exit 0, so the exit code can't be used).

**Why the macOS job matters:** clang treats implicit function declarations as hard errors, gcc only warns. So a missing declaration builds clean on Linux but fails outright for every macOS user — most recently the `update_files()` declaration fixed in aed554a, and the same class of break as #289. Since you develop on Linux, this job catches those before a release does.

**The Linux job also gets `CFLAGS=-Werror=implicit-function-declaration`** (applied at make time only, and `Makefile.in`'s `CFLAGS +=` keeps `$(DEFINES)` intact), so gcc fails on that class of break too — a red X on the cheap fast job even if the macOS queue is slow.

**The macOS configure needs three extra flags** because Homebrew on Apple Silicon installs under `/opt/homebrew`, which neither `configure`'s header probes nor the compile line search by default: `--includedir` feeds `@MYINCLUDE@`/`INCS`, `CPPFLAGS` satisfies the `AC_CHECK_HEADERS` probes, and `LDFLAGS` covers the link.

Verified end-to-end on my fork before opening this — both jobs green: https://github.com/jaypatrickhoward/tintin/actions/runs/32691048782 (linux 50s, macos 26s; both runners are free for public repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)