### PR TITLE
Fix four memory-safety bugs in the telnet, colour and chat parsers

### DIFF
--- a/src/chat.c
+++ b/src/chat.c
@@ -34,7 +34,7 @@ extern  int chat_new(int s);
 extern void chat_printf(char *format, ...);
 extern  int process_chat_input(struct chat_data *buddy);
 extern void get_chat_commands(struct chat_data *buddy, char *buf, int len);
-extern void chat_name_change(struct chat_data *buddy, char *txt);
+extern struct chat_data *chat_name_change(struct chat_data *buddy, char *txt);
 extern void chat_receive_text_everybody(struct chat_data *buddy, char *txt);
 extern void chat_receive_text_personal(struct chat_data *buddy, char *txt);
 extern void chat_receive_text_group(struct chat_data *buddy, char *txt);
@@ -866,7 +866,7 @@ void get_chat_commands(struct chat_data *buddy, char *buf, int len)
 		switch (ptc)
 		{
 			case CHAT_NAME_CHANGE:
-				chat_name_change(buddy, txt);
+				buddy = chat_name_change(buddy, txt);
 				break;
 
 			case CHAT_REQUEST_CONNECTIONS:
@@ -977,7 +977,7 @@ void get_chat_commands(struct chat_data *buddy, char *buf, int len)
 }
 
 
-void chat_name_change(struct chat_data *buddy, char *name)
+struct chat_data *chat_name_change(struct chat_data *buddy, char *name)
 {
 	struct chat_data *node;
 
@@ -989,7 +989,7 @@ void chat_name_change(struct chat_data *buddy, char *name)
 
 		close_chat(buddy, TRUE);
 
-		return;
+		return NULL;
 	}
 
 	for (node = gtd->chat ; node ; node = node->next)
@@ -1002,7 +1002,7 @@ void chat_name_change(struct chat_data *buddy, char *name)
 
 			close_chat(buddy, TRUE);
 
-			return;
+			return NULL;
 		}
 	}
 
@@ -1014,7 +1014,7 @@ void chat_name_change(struct chat_data *buddy, char *name)
 
 		close_chat(buddy, TRUE);
 
-		return;
+		return NULL;
 	}
 
 	if (strcmp(name, buddy->name))
@@ -1023,6 +1023,8 @@ void chat_name_change(struct chat_data *buddy, char *name)
 
 		RESTRING(buddy->name, name);
 	}
+
+	return buddy;
 }
 
 void chat_receive_text_everybody(struct chat_data *buddy, char *txt)

--- a/src/substitute.c
+++ b/src/substitute.c
@@ -1907,7 +1907,7 @@ int substitute(struct session *ses, char *string, char *result, int flags)
 						}
 						pti += sprintf(old, "<F%c%c%c>", pti[2], pti[3], pti[4]);
 					}
-					else if (toupper((int) pti[1]) == 'F' && (pti[2] == '?' || pti[3] == '?' || pti[4] == '?') && pti[5] == '>')
+					else if (toupper((int) pti[1]) == 'F' && pti[2] && pti[3] && pti[4] && (pti[2] == '?' || pti[3] == '?' || pti[4] == '?') && pti[5] == '>')
 					{
 						c4096_rnd(ses, &pti[2]);
 
@@ -1957,7 +1957,7 @@ int substitute(struct session *ses, char *string, char *result, int flags)
 						}
 						pti += sprintf(old, "<B%c%c%c>", pti[2], pti[3], pti[4]);
 					}
-					else if (toupper((int) pti[1]) == 'B' && (pti[2] == '?' || pti[3] == '?' || pti[4] == '?') && pti[5] == '>')
+					else if (toupper((int) pti[1]) == 'B' && pti[2] && pti[3] && pti[4] && (pti[2] == '?' || pti[3] == '?' || pti[4] == '?') && pti[5] == '>')
 					{
 						c4096_rnd(ses, &pti[2]);
 

--- a/src/telopt_client.c
+++ b/src/telopt_client.c
@@ -1725,7 +1725,10 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 				break;
 
 			case '}':
-				nest--;
+				if (nest)
+				{
+					nest--;
+				}
 				i++;
 				if (nest != 0)
 				{
@@ -1744,7 +1747,10 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 				break;
 
 			case ']':
-				nest--;
+				if (nest)
+				{
+					nest--;
+				}
 				i++;
 				if (nest != 0)
 				{

--- a/src/telopt_client.c
+++ b/src/telopt_client.c
@@ -953,7 +953,7 @@ int client_recv_sb_mssp(struct session *ses, int cplen, unsigned char *src)
 
 int client_recv_sb_msdp(struct session *ses, int cplen, unsigned char *src)
 {
-	char var[BUFFER_SIZE], val[BUFFER_SIZE], plain[BUFFER_SIZE], *pto;
+	char var[BUFFER_SIZE], val[BUFFER_SIZE], plain[BUFFER_SIZE], *pto, *ptb;
 	int i, nest, state[100], last;
 
 	var[0] = val[0] = state[0] = nest = last = 0;
@@ -965,8 +965,9 @@ int client_recv_sb_msdp(struct session *ses, int cplen, unsigned char *src)
 
 	i = 3;
 	pto = var;
+	ptb = var;
 
-	while (i < cplen && nest < 99)
+	while (i < cplen && nest < 99 && pto - ptb < BUFFER_SIZE - 32)
 	{
 		if (src[i] == IAC && src[i+1] == SE)
 		{
@@ -1040,6 +1041,7 @@ int client_recv_sb_msdp(struct session *ses, int cplen, unsigned char *src)
 						check_all_events(ses, EVENT_FLAG_TELNET, 0, 3, "IAC SB MSDP", var, val, plain);
 					}
 					pto = var;
+					ptb = var;
 				}
 				last = MSDP_VAR;
 				break;
@@ -1069,6 +1071,7 @@ int client_recv_sb_msdp(struct session *ses, int cplen, unsigned char *src)
 						check_all_events(ses, EVENT_FLAG_TELNET, 0, 3, "IAC SB MSDP", var, val, plain);
 					}
 					pto = val;
+					ptb = val;
 				}
 				last = MSDP_VAL;
 				break;
@@ -1125,8 +1128,9 @@ int client_recv_sb_msdp(struct session *ses, int cplen, unsigned char *src)
 
 	i = 3;
 	pto = var;
+	ptb = var;
 
-	while (i < cplen && nest < 99)
+	while (i < cplen && nest < 99 && pto - ptb < BUFFER_SIZE - 32)
 	{
 		if (src[i] == IAC && src[i+1] == SE)
 		{
@@ -1199,6 +1203,7 @@ int client_recv_sb_msdp(struct session *ses, int cplen, unsigned char *src)
 						check_all_events(ses, EVENT_FLAG_TELNET, 0, 2, "IAC SB MSDP2JSON", var, plain);
 					}
 					pto = var;
+					ptb = var;
 				}
 				last = MSDP_VAR;
 				break;
@@ -1233,6 +1238,7 @@ int client_recv_sb_msdp(struct session *ses, int cplen, unsigned char *src)
 						check_all_events(ses, EVENT_FLAG_TELNET, 0, 2, "IAC SB MSDP2JSON", var, plain);
 					}
 					pto = val;
+					ptb = val;
 				}
 				last = MSDP_VAL;
 				break;
@@ -1654,7 +1660,7 @@ int client_recv_sb_zmp(struct session *ses, int cplen, unsigned char *src)
 
 int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 {
-	char mod[BUFFER_SIZE], val[BUFFER_SIZE], json[BUFFER_SIZE], *pto;
+	char mod[BUFFER_SIZE], val[BUFFER_SIZE], json[BUFFER_SIZE], *pto, *ptb;
 	int i, state[100], nest, type;
 
 	push_call("client_recv_sb_gmcp(%p,%d,%p)",ses,cplen,src);
@@ -1670,6 +1676,7 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 	i = 3;
 
 	pto = mod;
+	ptb = mod;
 
 	// space out
 
@@ -1680,7 +1687,7 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 
 	// grab module
 
-	while (i < cplen && src[i] != IAC)
+	while (i < cplen && src[i] != IAC && pto - ptb < BUFFER_SIZE - 32)
 	{
 		if (src[i] == ' ' || src[i] == '{' || src[i] == '[')
 		{
@@ -1694,8 +1701,9 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 	// parse JSON content
 
 	pto = val;
+	ptb = val;
 
-	while (i < cplen && src[i] != IAC && nest < 99)
+	while (i < cplen && src[i] != IAC && nest < 99 && pto - ptb < BUFFER_SIZE - 32)
 	{
 		switch (src[i])
 		{
@@ -1768,7 +1776,7 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 				}
 				type = 1;
 
-				while (i < cplen && src[i] != IAC && type == 1)
+				while (i < cplen && src[i] != IAC && type == 1 && pto - ptb < BUFFER_SIZE - 32)
 				{
 					switch (src[i])
 					{
@@ -1836,7 +1844,7 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 
 				type = 1;
 
-				while (i < cplen && src[i] != IAC && type == 1)
+				while (i < cplen && src[i] != IAC && type == 1 && pto - ptb < BUFFER_SIZE - 32)
 				{
 					switch (src[i])
 					{
@@ -1869,9 +1877,10 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 	// Raw json data for debugging purposes.
 
 	pto = json;
+	ptb = json;
 	i = 3;
 
-	while (i < cplen && src[i] != IAC)
+	while (i < cplen && src[i] != IAC && pto - ptb < BUFFER_SIZE - 32)
 	{
 		switch (src[i])
 		{
@@ -2252,7 +2261,7 @@ int client_recv_sb(struct session *ses, int cplen, unsigned char *cpsrc)
 	pt1 = var1;
 	pt2 = var2;
 
-	for (i = 3 ; i < cplen ; i++)
+	for (i = 3 ; i < cplen && pt2 - var2 < BUFFER_SIZE - 20 ; i++)
 	{
 		if (cpsrc[i] == IAC && i + 1 < cplen && cpsrc[i+1] == SE)
 		{


### PR DESCRIPTION
Four memory-safety bugs, each reachable from data the client does not control. All four reproduce on `1f987c3` and were found with a sanitiser build driven by a fuzzer. One commit per category.

**Each fix reuses a pattern already present in the tree rather than introducing a new one** — in every case the same situation is already handled correctly somewhere else, and these are the places that were missed.

### 1. Oversized telnet sub-negotiations overflow their working buffers

**Trigger:** a connected server sends a sub-negotiation — the out-of-band channel the MUD protocols ride on — that is far larger than the client expects. The payload is copied into a fixed-size working area while being expanded on the way in, so a payload noticeably *smaller* than that area can still overrun it. Nothing has to be negotiated or agreed first; these are processed as soon as they arrive, on any option, including ones the client doesn't implement.

**Payload:** a sub-negotiation carrying **15,000 bytes** is enough; 14,999 is not. The same shape reaches all three parsers (the generic handler, MSDP and GMCP).

*Fix — existing pattern:* the guard is the one already used in seven places: `pto - bufi >= BUFFER_SIZE` (`files.c`), `pti - input < BUFFER_SIZE / 2` (`input.c`), `ptr - buf > STRING_SIZE - BUFFER_SIZE` (`msdp.c`), `pto - result >= BUFFER_SIZE - 3` (`parse.c`), `pto - out > BUFFER_SIZE - 1000` (`substitute.c`), and `pto - textout < BUFFER_SIZE` / `- 20` (`text.c`). Two of these parsers move their output between several buffers, so they track the current buffer's base and compare against that; the third takes the one-line form directly.

### 2. Unbalanced GMCP brackets drive the nesting level negative

**Trigger:** a server sends a GMCP message whose JSON has more closing brackets or braces than opening ones. The parser tracks how deep it currently is; an unmatched close takes that count below zero, and it is then used to look up a position in a small table that doesn't exist.

**Payload:** **9 bytes** — `FF FA C9 9A 20 5D 73 FF F0`. A single stray `]` is the whole trick. GMCP is widely negotiated, so this is the easiest of the four to hit.

*Fix — existing pattern:* MSDP already refuses to decrement past zero in its own close markers, at `telopt_client.c:985` and `:1007` (and again at `:1149` / `:1169`). This applies the identical guard to the GMCP equivalents, which is the same file and the same idea, just not carried across.

### 3. A truncated colour code reads past the end of the string

**Trigger:** text that ends in an incomplete colour code — specifically the random-colour form, where the parser checks several following characters to decide what it's looking at and can walk past the terminator when the text stops early. The colour expansion runs over messages received from chat peers, so the text need not be locally authored.

**Payload:** **6 bytes** — `41 3C 66 A2 3C 66`, i.e. anything ending in a truncated random-colour marker.

*Fix — existing pattern:* the surrounding forms already require each character to exist before testing it — `substitute.c:1782`, and `:2093` / `:2101` in the same file — and the fixed-digit variants are safe for the same reason, since `is_hex()` stops at the terminator. Only the two random-colour forms skipped it; this brings them into line. The foreground one was found by fuzzing, the background twin by reading its neighbours.

### 4. A chat peer is used after it has been disconnected

**Trigger:** a chat peer sends one packet containing several commands, where an early command makes the client reject the peer and drop it — for example, asking for a name the client won't allow. The remaining commands in that same packet are then still processed on behalf of a peer that no longer exists.

**Payload:** **26 bytes** — a name change to a name that is too long, followed by any second command, in a single packet.

*Fix — existing pattern:* `chat.c:558` already has the caller decide what to do when a routine reports the peer should go (`process_chat_input(buddy) < 0`), and returning the possibly-changed object is the house style throughout — `DO_COMMAND` itself returns `struct session *`. So the routine that can drop the peer now reports whether it survived. The command loop already guarded on the peer still being present; it just had no way to find out.

---

### Verification

* Every reported case, plus larger variants of each, is clean under AddressSanitizer.
* The fuzzers that found these were re-run against the patch: the telnet target went from **398 crashes to 0** at *higher* coverage (1384 vs 1341), the chat target 728k executions clean, the substitute target 243k clean. Controls confirm the same harnesses still detect the bugs on unpatched sources, so the zeroes aren't vacuous.
* `tt++ -l validate` passes, unchanged.
* Output over a 1 MB captured session is **byte-identical** to before the patch, as is the parsed result for valid nested MSDP and GMCP and for every deterministic colour code.
* No new compiler warnings (476 before, 476 after).
* Each commit builds on its own.

### One behavioural note

The bounds stop slightly short of the buffer end, so a payload whose parsed output lands within about 25 bytes of the absolute maximum is now truncated. Measured: identical output up to 59,795 bytes; at 59,990 the patched build produces 16 fewer; **past that the unpatched build doesn't produce more, it produces garbage** — the value collapses to 61 bytes once it overruns. Real traffic in a captured session peaks at 55 bytes of parsed output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
