### PR TITLE
allow escaped '/' in gmcp strings

### DIFF
--- a/src/telopt_client.c
+++ b/src/telopt_client.c
@@ -1847,7 +1847,7 @@ int client_recv_sb_gmcp(struct session *ses, int cplen, unsigned char *src)
 						case '\\':
 							i++;
 
-							if (i < cplen && src[i] == '"')
+							if (i < cplen && (src[i] == '"' || src[i] == '/'))
 							{
 								*pto++ = src[i++];
 							}


### PR DESCRIPTION
JSON allows to (optionally) escape '/'.
This seems to be how the json-c library (which is used by ldmud) encodes strings.